### PR TITLE
Android assets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,24 @@ ZipArchive.unzip(sourcePath, targetPath)
   console.log(error)
 })
 ```
+
+**unzipAssets(assetPath: string, target: string): Promise**
+
+> unzip file from Android `assets` folder to target path
+
+Note: Android only.
+
+`assetPath` is the relative path to the file inside the pre-bundled assets folder, e.g. `folder/myFile.zip`. Do not pass an absolute directory.
+
+```js
+let assetPath = 'folder/myFile.zip' 
+let targetPath = RNFS.DocumentDirectoryPath
+
+ZipArchive.unzipAssets(assetPath, targetPath)
+.then(() => {
+  console.log('unzip completed!')
+})
+.catch((error) => {
+  console.log(error)
+})
+```

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var RNZipArchive = require('react-native').NativeModules.RNZipArchive
 var promisify = require("es6-promisify")
 
 var _unzip = promisify(RNZipArchive.unzip)
+var _unzipAssets = RNZipArchive.unzipAssets ? promisify(RNZipArchive.unzipAssets) : undefined
 
 var _error = (err) => {
   throw err
@@ -13,7 +14,16 @@ var ZipArchive = {
   unzip(source, target) {
     return _unzip(source, target)
       .catch(_error)
+  },
+  unzipAssets(source, target) {
+  	if (!_unzipAssets) {
+  		throw new Exception("unzipAssets not supported on this platform");
+  	}
+
+  	return _unzipAssets(source, target)
+  		.catch(_error)
   }
+
 }
 
 module.exports = ZipArchive


### PR DESCRIPTION
Added support for unzipping a file stored in the Android assets folder via a new `unzipAssets` method. Added to documentation. On iOS (or Windows now I guess!) this method will throw an exception 'unzipAssets not supported on this platform'