### PR TITLE
Fix wrong type of thrown object (now 'Error')

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var ZipArchive = {
   },
   unzipAssets(source, target) {
   	if (!_unzipAssets) {
-  		throw new Exception("unzipAssets not supported on this platform");
+  		throw new Error("unzipAssets not supported on this platform");
   	}
 
   	return _unzipAssets(source, target)


### PR DESCRIPTION
One of our devs pointed out that I'd thrown an 'Exception' (undefined in JS) rather than an 'Error' when unzipAssets was run on iOS.  Fixed. 