### PR TITLE
Android: Fix unzip failure if destDir has 2+ folders to mkdir

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -73,7 +73,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
     try {
       File destDir = new File(destDirectory);
       if (!destDir.exists()) {
-        destDir.mkdir();
+        destDir.mkdirs();
       }
       ZipInputStream zipIn = new ZipInputStream(inputStream);
       ZipEntry entry = zipIn.getNextEntry();


### PR DESCRIPTION
one character change - mkdirs() creates *all* the folders in the path. mkdir() will only create one level.