### PR TITLE
Migrate headers for RN 0.40 compatibility

### DIFF
--- a/RNZipArchive.h
+++ b/RNZipArchive.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Perry Poon. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import "SSZipArchive/SSZipArchive.h"
 
 @interface RNZipArchive : NSObject<RCTBridgeModule, SSZipArchiveDelegate>

--- a/RNZipArchive.m
+++ b/RNZipArchive.m
@@ -8,8 +8,8 @@
 
 #import "RNZipArchive.h"
 
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
 
 @implementation RNZipArchive
 

--- a/RNZipArchive.xcodeproj/project.pbxproj
+++ b/RNZipArchive.xcodeproj/project.pbxproj
@@ -351,9 +351,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../react-native/Libraries/Image/**",
+					"$(SRCROOT)/../react-native/React",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -367,9 +365,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../react-native/Libraries/Image/**",
+					"$(SRCROOT)/../react-native/React",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
As reported in #23, RN 0.40 comes with some compatibility-breaks. This PR will fix them. 

See also: https://github.com/facebook/react-native/releases/tag/v0.40.0